### PR TITLE
Update the Key Vault Name to prevent Naming Conflicts

### DIFF
--- a/terraform/aks/key-vault.tf
+++ b/terraform/aks/key-vault.tf
@@ -1,6 +1,6 @@
 # Create a Key Vault for storing secrets
 resource "azurerm_key_vault" "main" {
-  name                = "${substr(replace(var.cluster_name, "-", ""), 0, 20)}kv"
+  name                = "${substr(replace(var.cluster_name, "-", ""), 0, 14)}${substr(replace(local.effective_user_suffix, "-", ""), 0, 6)}kv"
   resource_group_name = azurerm_resource_group.aks.name
   location            = azurerm_resource_group.aks.location
   tenant_id           = data.azurerm_client_config.current.tenant_id
@@ -13,7 +13,7 @@ resource "azurerm_key_vault" "main" {
   soft_delete_retention_days = 7
   purge_protection_enabled   = false # Set to true in production
 
-  tags = var.tags
+  tags = merge(var.tags, { Owner = local.effective_user_suffix })
 }
 
 # Grant the current user/service principal access to manage secrets


### PR DESCRIPTION
# Description

There is a KV name conflict.  This adds a user name tag to the resource to prevent this.