### PR TITLE
feat: add StackAI version management functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ help:
 	@echo "  setup-docker-in-ubuntu: Launch the script that is responsible for setting up Docker in Ubuntu"
 	@echo "  run-postgres-migrations: Run the Postgres migrations"
 	@echo "  configure-domains: Configure the service domains in the .env files"
+	@echo "  stackai-version: Update StackAI service versions (usage: make stackai-version version=1.0.2)"
 	@echo "  help: Show this help message"
 
 .PHONY: initialize_mongodb
@@ -141,6 +142,26 @@ saml-delete-provider:
 	@cd scripts/supabase && \
 		chmod +x saml_delete_provider.sh && \
 		./saml_delete_provider.sh "$(provider_id)"
+
+# ==================================================================================================
+#                                        VERSION MANAGEMENT
+# ==================================================================================================
+.PHONY: stackai-version
+stackai-version:
+	@if [ -z "$(version)" ]; then \
+		echo "❌ Error: version is required"; \
+		echo ""; \
+		echo "Usage:"; \
+		echo "  make stackai-version version=1.0.2"; \
+		echo ""; \
+		echo "Available versions can be found in scripts/docker/stackai-versions.json"; \
+		echo ""; \
+		exit 1; \
+	fi
+	@echo "🔄 Updating StackAI services to version $(version)..."
+	@cd scripts/docker && \
+		chmod +x update_stackai_versions.py && \
+		python3 update_stackai_versions.py "$(version)"
 
 # ==================================================================================================
 #                                        UPDATE REPOSITORY

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -1,0 +1,105 @@
+# StackAI Version Management
+
+This directory contains tools for managing StackAI service versions across the on-premise deployment.
+
+## Files
+
+- `stackai-versions.json` - Configuration file containing version mappings
+- `update_stackai_versions.py` - Python script that updates service versions
+- `README.md` - This documentation file
+
+## Configuration Format
+
+The `stackai-versions.json` file contains an array of version objects. Each object maps a release version to specific service versions:
+
+```json
+[
+  {
+    "1.0.2": {
+      "stackend": "v1.0.2",
+      "stackweb": "v1.0.3",
+      "stackrepl": "v1.0.0"
+    }
+  }
+]
+```
+
+## Usage
+
+### Using Make (Recommended)
+
+```bash
+# Update to a specific version
+make stackai-version version=1.0.2
+
+# Show help
+make stackai-version
+```
+
+### Using Python Script Directly
+
+```bash
+# Update to a specific version
+python3 scripts/docker/update_stackai_versions.py 1.0.2
+
+# Show help
+python3 scripts/docker/update_stackai_versions.py
+```
+
+## What Gets Updated
+
+The script updates the following files:
+
+1. **stackend/docker-compose.yml**
+
+   - `stackai.azurecr.io/stackai/stackend-celery-worker:VERSION`
+   - `stackai.azurecr.io/stackai/stackend-backend:VERSION`
+
+2. **stackweb/Dockerfile**
+
+   - `FROM stackai.azurecr.io/stackai/stackweb:VERSION`
+
+3. **stackrepl/docker-compose.yml**
+   - `stackai.azurecr.io/stackai/stackrepl/stack-repl:VERSION`
+
+## Adding New Versions
+
+To add a new version configuration:
+
+1. Edit `scripts/docker/stackai-versions.json`
+2. Add a new object with the version and service mappings:
+
+```json
+{
+  "1.0.3": {
+    "stackend": "v1.0.3",
+    "stackweb": "v1.0.4",
+    "stackrepl": "v1.0.1"
+  }
+}
+```
+
+## After Updating Versions
+
+After running the version update script, you should:
+
+1. **Review changes**: `git diff`
+2. **Update services**: `make update` (pulls new images and restarts services)
+3. **Commit changes**: `git add . && git commit -m "Update to version X.X.X"`
+
+## Example Workflow
+
+```bash
+# 1. Update to new version
+make stackai-version version=1.0.2
+
+# 2. Review the changes
+git diff
+
+# 3. Update and restart services
+make update
+
+# 4. Commit the changes
+git add .
+git commit -m "Update StackAI services to version 1.0.2"
+```

--- a/scripts/docker/stackai-versions.json
+++ b/scripts/docker/stackai-versions.json
@@ -1,0 +1,23 @@
+[
+  {
+    "1.0.0": {
+      "stackend": "v1.0.0",
+      "stackweb": "v1.0.0",
+      "stackrepl": "v1.0.0"
+    }
+  },
+  {
+    "1.0.1": {
+      "stackend": "v1.0.1",
+      "stackweb": "v1.0.1",
+      "stackrepl": "v1.0.0"
+    }
+  },
+  {
+    "1.0.2": {
+      "stackend": "v1.0.2",
+      "stackweb": "v1.0.3",
+      "stackrepl": "v1.0.0"
+    }
+  }
+]

--- a/scripts/docker/update_stackai_versions.py
+++ b/scripts/docker/update_stackai_versions.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+StackAI Version Manager
+
+This script updates the Docker image versions for StackAI services based on a JSON configuration file.
+It updates the following files:
+- stackend/docker-compose.yml (stackend-backend and stackend-celery-worker images)
+- stackweb/Dockerfile (stackweb image)
+- stackrepl/docker-compose.yml (stackrepl image)
+
+Usage:
+    python update_stackai_versions.py <version>
+    
+Example:
+    python update_stackai_versions.py 1.0.2
+"""
+
+import json
+import sys
+import os
+import re
+from pathlib import Path
+
+def load_versions_config(config_path):
+    """Load the versions configuration from JSON file."""
+    try:
+        with open(config_path, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"❌ Error: Configuration file not found: {config_path}")
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"❌ Error: Invalid JSON in configuration file: {e}")
+        sys.exit(1)
+
+def find_version_config(versions_config, target_version):
+    """Find the version configuration for the target version."""
+    for version_obj in versions_config:
+        if target_version in version_obj:
+            return version_obj[target_version]
+    return None
+
+def update_stackend_compose(stackend_version):
+    """Update stackend/docker-compose.yml with new versions."""
+    file_path = Path("stackend/docker-compose.yml")
+    
+    if not file_path.exists():
+        print(f"❌ Error: File not found: {file_path}")
+        return False
+    
+    try:
+        with open(file_path, 'r') as f:
+            content = f.read()
+        
+        # Update stackend-celery-worker image
+        content = re.sub(
+            r'image: stackai\.azurecr\.io/stackai/stackend-celery-worker:[^\s]+',
+            f'image: stackai.azurecr.io/stackai/stackend-celery-worker:{stackend_version}',
+            content
+        )
+        
+        # Update stackend-backend image
+        content = re.sub(
+            r'image: stackai\.azurecr\.io/stackai/stackend-backend:[^\s]+',
+            f'image: stackai.azurecr.io/stackai/stackend-backend:{stackend_version}',
+            content
+        )
+        
+        with open(file_path, 'w') as f:
+            f.write(content)
+        
+        print(f"✅ Updated {file_path} with stackend version {stackend_version}")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Error updating {file_path}: {e}")
+        return False
+
+def update_stackweb_dockerfile(stackweb_version):
+    """Update stackweb/Dockerfile with new version."""
+    file_path = Path("stackweb/Dockerfile")
+    
+    if not file_path.exists():
+        print(f"❌ Error: File not found: {file_path}")
+        return False
+    
+    try:
+        with open(file_path, 'r') as f:
+            content = f.read()
+        
+        # Update FROM line with new stackweb version
+        content = re.sub(
+            r'FROM stackai\.azurecr\.io/stackai/stackweb:[^\s]+',
+            f'FROM stackai.azurecr.io/stackai/stackweb:{stackweb_version}',
+            content
+        )
+        
+        with open(file_path, 'w') as f:
+            f.write(content)
+        
+        print(f"✅ Updated {file_path} with stackweb version {stackweb_version}")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Error updating {file_path}: {e}")
+        return False
+
+def update_stackrepl_compose(stackrepl_version):
+    """Update stackrepl/docker-compose.yml with new version."""
+    file_path = Path("stackrepl/docker-compose.yml")
+    
+    if not file_path.exists():
+        print(f"❌ Error: File not found: {file_path}")
+        return False
+    
+    try:
+        with open(file_path, 'r') as f:
+            content = f.read()
+        
+        # Update stackrepl image
+        content = re.sub(
+            r'image: stackai\.azurecr\.io/stackai/stackrepl/stack-repl:[^\s]+',
+            f'image: stackai.azurecr.io/stackai/stackrepl/stack-repl:{stackrepl_version}',
+            content
+        )
+        
+        with open(file_path, 'w') as f:
+            f.write(content)
+        
+        print(f"✅ Updated {file_path} with stackrepl version {stackrepl_version}")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Error updating {file_path}: {e}")
+        return False
+
+def main():
+    if len(sys.argv) != 2:
+        print("❌ Error: Version argument is required")
+        print("")
+        print("Usage:")
+        print("  python update_stackai_versions.py <version>")
+        print("")
+        print("Example:")
+        print("  python update_stackai_versions.py 1.0.2")
+        sys.exit(1)
+    
+    target_version = sys.argv[1]
+    
+    # Get the script directory and config file path
+    script_dir = Path(__file__).parent
+    config_path = script_dir / "stackai-versions.json"
+    
+    # Change to the repository root directory
+    repo_root = script_dir.parent.parent
+    os.chdir(repo_root)
+    
+    print(f"🔄 Updating StackAI services to version {target_version}...")
+    print(f"📁 Working directory: {os.getcwd()}")
+    print(f"📄 Config file: {config_path}")
+    
+    # Load versions configuration
+    versions_config = load_versions_config(config_path)
+    
+    # Find the version configuration
+    version_config = find_version_config(versions_config, target_version)
+    if not version_config:
+        print(f"❌ Error: Version {target_version} not found in configuration")
+        print("")
+        print("Available versions:")
+        for version_obj in versions_config:
+            for version in version_obj.keys():
+                print(f"  - {version}")
+        sys.exit(1)
+    
+    print(f"📋 Version configuration found:")
+    for service, version in version_config.items():
+        print(f"  - {service}: {version}")
+    print("")
+    
+    # Update each service
+    success = True
+    
+    # Update stackend
+    if 'stackend' in version_config:
+        success &= update_stackend_compose(version_config['stackend'])
+    
+    # Update stackweb
+    if 'stackweb' in version_config:
+        success &= update_stackweb_dockerfile(version_config['stackweb'])
+    
+    # Update stackrepl
+    if 'stackrepl' in version_config:
+        success &= update_stackrepl_compose(version_config['stackrepl'])
+    
+    if success:
+        print("")
+        print(f"🎉 Successfully updated all StackAI services to version {target_version}")
+        print("")
+        print("Next steps:")
+        print("  1. Review the changes: git diff")
+        print("  2. Rebuild and restart services: make update")
+    else:
+        print("")
+        print("❌ Some updates failed. Please check the errors above.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/stackend/docker-compose.yml
+++ b/stackend/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   celery_worker:
     container_name: celery_worker
     restart: always
-    image: stackai.azurecr.io/stackai/stackend-celery-worker:v1.0.1
+    image: stackai.azurecr.io/stackai/stackend-celery-worker:v1.0.2
     env_file:
       - .env
     depends_on:
@@ -24,7 +24,7 @@ services:
   stackend:
     container_name: stackend
     restart: always
-    image: stackai.azurecr.io/stackai/stackend-backend:v1.0.1
+    image: stackai.azurecr.io/stackai/stackend-backend:v1.0.2
     env_file:
       - .env
     depends_on:

--- a/stackweb/Dockerfile
+++ b/stackweb/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackai.azurecr.io/stackai/stackweb:v1.0.1
+FROM stackai.azurecr.io/stackai/stackweb:v1.0.3
 
 ARG GOOGLE_CLIENT_EMAIL
 ARG GOOGLE_SERVICE_PRIVATE_KEY


### PR DESCRIPTION
- Introduced a new Makefile target `stackai-version` for updating StackAI service versions.
- Added a Python script `update_stackai_versions.py` to automate version updates based on a JSON configuration.
- Created `stackai-versions.json` to manage service version mappings.
- Updated Docker images in `stackend` and `stackweb` to their respective new versions.
- Added documentation in `scripts/docker/README.md` for version management usage and configuration.

<img width="1064" height="548" alt="image" src="https://github.com/user-attachments/assets/4ab5438e-50d4-4ff9-9099-d01ef699e5ba" />