### PR TITLE
feat: make to add SSO domain registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ make run-template-migrations
    make saml-status
    ```
 
+3. Register SSO Domains
+
+   ```sh
+   make register-sso-domain provider=example.com org_id=123e4567-e89b-12d3-a456-426614174000 role=editor
+   ```
+
 ### Register Providers
 
 1. Run `make saml-add-provider metadata_url='{idp-metadata-ur}' domains='{comma-sepparated-domains}'`

--- a/scripts/docker/stackai-versions.json
+++ b/scripts/docker/stackai-versions.json
@@ -19,5 +19,12 @@
       "stackweb": "v1.0.3",
       "stackrepl": "v1.0.0"
     }
+  },
+  {
+    "1.0.3": {
+      "stackend": "v1.0.3",
+      "stackweb": "v1.0.3",
+      "stackrepl": "v1.0.0"
+    }
   }
 ]

--- a/stackend/docker-compose.yml
+++ b/stackend/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   celery_worker:
     container_name: celery_worker
     restart: always
-    image: stackai.azurecr.io/stackai/stackend-celery-worker:v1.0.2
+    image: stackai.azurecr.io/stackai/stackend-celery-worker:v1.0.3
     env_file:
       - .env
     depends_on:
@@ -24,7 +24,7 @@ services:
   stackend:
     container_name: stackend
     restart: always
-    image: stackai.azurecr.io/stackai/stackend-backend:v1.0.2
+    image: stackai.azurecr.io/stackai/stackend-backend:v1.0.3
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
- Introduced a new Makefile target `register-sso-domain` for registering SSO domains with required parameters.
- Added detailed usage instructions and parameter descriptions for the new target in the Makefile.
- Updated README to include instructions for registering SSO domains, enhancing documentation for user clarity.
