### PR TITLE
docs: update README and Docker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the configuration needed to run StackAI locally using d
 
 1. At least 64GB of RAM
 2. At least 16 CPU cores
-3. 1TB of disk space
+3. 1TB of disk space in `/var` directory.
 
 ## Software
 
@@ -316,3 +316,8 @@ make run-template-migrations
 1. Run `make saml-add-provider metadata_url='{idp-metadata-ur}' domains='{comma-sepparated-domains}'`
 2. You can list saml providers running `make saml-list-providers`
 3. You can delete providers running `make saml-delete-provider provider_id='{provider-id}'`
+
+## Docker cleaning
+```sh
+docker compose down --rmi all --volumes --remove-orphans
+```

--- a/weaviate/docker-compose.yml
+++ b/weaviate/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "9090"
       - --scheme
       - http
-    image: cr.weaviate.io/semitechnologies/weaviate:1.26.6
+    image: cr.weaviate.io/semitechnologies/weaviate:1.27.0
     volumes:
       - ./weaviate_data:/var/lib/weaviate
     restart: on-failure


### PR DESCRIPTION
- Clarified disk space requirement in README to specify the `/var` directory.
- Added a new section in README for Docker cleaning instructions.
- Updated Weaviate Docker image version from 1.26.6 to 1.27.0 in docker-compose.yml.

# Description